### PR TITLE
Issue7 ignore

### DIFF
--- a/_reporter.js
+++ b/_reporter.js
@@ -6,7 +6,9 @@ const path = require("path");
 const oldData = JSON.parse(process.argv[2]);
 const newData = JSON.parse(process.argv[3]);
 const contractPath = path.parse(process.argv[4]);
+const ignoreNew = JSON.parse(process.argv[5]);
 
+console.log("Ignore is :", ignoreNew);
 // Skip if same
 if (JSON.stringify(oldData) === JSON.stringify(newData)) process.exit(0);
 
@@ -101,8 +103,10 @@ for (; i < alignedOldVisualized.length; i++) {
       }
     } else {
       if (!hasExisted(overlayedItem, oldVisualized)) {
+        if(!ignoreNew){
         printNew(true, "🌱");
         printOld(false);
+        }
       } else {
         printNew(true, "🏳️");
         printOld(false);
@@ -115,11 +119,28 @@ for (; i < alignedOldVisualized.length; i++) {
   }
 }
 
+// =========== ignore_if_all_new ==========================
+
+// Function to check for the presence of specified emojis
+function containsEmojis(str) {
+  const emojis = ["🏴", "🏳️", "🏁", "🪦"];
+  return emojis.some(emoji => str.includes(emoji));
+}
+
+// Check if reportNew contains any of the specified emojis
+ if(!containsEmojis(reportNew) && (ignoreNew)){
+  // console.log("No relevant emoji found, exiting script.");
+  process.exit(1); // Exit the script
+}
+
+
 // ========== REPORT FINDINGS ==========
 
 // remove \n from end of report
 reportOld = reportOld.slice(0, -1);
 reportNew = reportNew.slice(0, -1);
+
+
 
 const directoryPath = path.join("./storage_delta", contractPath.dir);
 

--- a/_reporter.js
+++ b/_reporter.js
@@ -8,7 +8,7 @@ const newData = JSON.parse(process.argv[3]);
 const contractPath = path.parse(process.argv[4]);
 const ignoreNew = JSON.parse(process.argv[5]);
 
-console.log("Ignore is :", ignoreNew);
+// console.log("Ignore is :", ignoreNew);
 // Skip if same
 if (JSON.stringify(oldData) === JSON.stringify(newData)) process.exit(0);
 
@@ -103,10 +103,8 @@ for (; i < alignedOldVisualized.length; i++) {
       }
     } else {
       if (!hasExisted(overlayedItem, oldVisualized)) {
-        if(!ignoreNew){
         printNew(true, "🌱");
         printOld(false);
-        }
       } else {
         printNew(true, "🏳️");
         printOld(false);
@@ -119,7 +117,7 @@ for (; i < alignedOldVisualized.length; i++) {
   }
 }
 
-// =========== ignore_if_all_new ==========================
+// ===========[ --skip -only-new ]==========================
 
 // Function to check for the presence of specified emojis
 function containsEmojis(str) {
@@ -129,7 +127,7 @@ function containsEmojis(str) {
 
 // Check if reportNew contains any of the specified emojis
  if(!containsEmojis(reportNew) && (ignoreNew)){
-  // console.log("No relevant emoji found, exiting script.");
+  console.log("\n-Note : Skipped, writing new report ( --skip = only-new)\n");
   process.exit(1); // Exit the script
 }
 

--- a/_reporter.js
+++ b/_reporter.js
@@ -5,12 +5,16 @@ const path = require("path");
 
 const oldData = JSON.parse(process.argv[2]);
 const newData = JSON.parse(process.argv[3]);
+
 const contractPath = path.parse(process.argv[4]);
-const ignoreNew = JSON.parse(process.argv[5]);
+const ignoreNew = process.argv[5];
 
 // console.log("Ignore is :", ignoreNew);
 // Skip if same
-if (JSON.stringify(oldData) === JSON.stringify(newData)) process.exit(0);
+if (JSON.stringify(oldData) === JSON.stringify(newData)) {
+  // console.log("\nReport Generation Skipped: No differences detected in storage layouts. This may indicate identical file contents.\n");
+  process.exit(0);
+}
 
 // ========== VISUALIZE LAYOUTS ==========
 
@@ -127,7 +131,7 @@ function containsEmojis(str) {
 
 // Check if reportNew contains any of the specified emojis
  if(!containsEmojis(reportNew) && (ignoreNew)){
-  console.log("\n-Note : Skipped, writing new report ( --skip = only-new)\n");
+  // console.log("\n-Note : Skipped, writing new report ( --skip = only-new)\n");
   process.exit(1); // Exit the script
 }
 

--- a/run.sh
+++ b/run.sh
@@ -1,34 +1,5 @@
 #!/bin/bash
 
-# Variable to store whether --ignore was used in parameters
-IGNORE_NEW=0
-POSITIONAL_ARGS=()
-
-# Parsing the command-line arguments
-while [[ $# -gt 0 ]]; do
-    case "$1" in
-        --skip)
-            shift # Remove --ignore from processing
-            if [[ $1 == "only-new" ]]; then
-                IGNORE_NEW=1
-                shift # Remove the value from processing
-            else
-                echo "Error: --skip requires a value (e.g., only-new)."
-                exit 1
-            fi
-            ;;
-        *)
-            # Store positional arguments
-            POSITIONAL_ARGS+=("$1")
-            shift
-            ;;
-    esac
-done
-
-# Restore positional arguments
-set -- "${POSITIONAL_ARGS[@]}"
-
-
 # CLONE OLD VERSION
 
 # Check if the commit hash argument is provided
@@ -70,6 +41,34 @@ if [ "$exists" -eq 0 ]; then
 fi
 
 # ========================================================================
+
+# Variable to store whether --skip was used in parameters
+IGNORE_NEW=0
+POSITIONAL_ARGS=()
+
+# Parsing the command-line arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --skip)
+            shift # Remove --skip from processing
+            if [[ $1 == "only-new" ]]; then
+                IGNORE_NEW=1
+                shift # Remove the value from processing
+            else
+                echo "Error: --skip requires a value ( choices:[ "only-new" ])"
+                exit 1
+            fi
+            ;;
+        *)
+            # Store positional arguments
+            POSITIONAL_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+# Restore positional arguments
+set -- "${POSITIONAL_ARGS[@]}"
 
 # GET FILE NAMES
 
@@ -141,7 +140,7 @@ for line in "${filesWithPath_old[@]}"; do
     output_old=$(forge inspect $formated_name storage)
     cd "$current_dir"
     output_new=$(forge inspect $formated_name storage)
-
+    
     node ./lib/storage-delta/_reporter.js "$output_old" "$output_new" ${line} $IGNORE_NEW
   fi
 done

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,34 @@
 #!/bin/bash
 
+# Variable to store whether --ignore was used in parameters
+IGNORE_NEW=0
+POSITIONAL_ARGS=()
+
+# Parsing the command-line arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --skip)
+            shift # Remove --ignore from processing
+            if [[ $1 == "only-new" ]]; then
+                IGNORE_NEW=1
+                shift # Remove the value from processing
+            else
+                echo "Error: --skip requires a value (e.g., only-new)."
+                exit 1
+            fi
+            ;;
+        *)
+            # Store positional arguments
+            POSITIONAL_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+# Restore positional arguments
+set -- "${POSITIONAL_ARGS[@]}"
+
+
 # CLONE OLD VERSION
 
 # Check if the commit hash argument is provided
@@ -113,6 +142,6 @@ for line in "${filesWithPath_old[@]}"; do
     cd "$current_dir"
     output_new=$(forge inspect $formated_name storage)
 
-    node ./lib/storage-delta/_reporter.js "$output_old" "$output_new" ${line}
+    node ./lib/storage-delta/_reporter.js "$output_old" "$output_new" ${line} $IGNORE_NEW
   fi
 done

--- a/run.sh
+++ b/run.sh
@@ -8,6 +8,34 @@ if [ -z "$1" ]; then
     exit 1
 fi
 
+# Variable to store whether --skip was used in parameters
+IGNORE_NEW=0
+POSITIONAL_ARGS=()
+
+# Parsing the command-line arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --skip)
+            shift # Remove --skip from processing
+            if [[ $1 == "only-new" ]]; then
+                IGNORE_NEW=1
+                shift # Remove the value from processing
+            else
+                echo "Error: --skip requires a value ( choices:[ "only-new" ])"
+                exit 1
+            fi
+            ;;
+        *)
+            # Store positional arguments
+            POSITIONAL_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+# Restore positional arguments
+set -- "${POSITIONAL_ARGS[@]}"
+
 # Define the path to the new subdirectory
 old_version=".storage_delta_cache/"
 
@@ -41,34 +69,6 @@ if [ "$exists" -eq 0 ]; then
 fi
 
 # ========================================================================
-
-# Variable to store whether --skip was used in parameters
-IGNORE_NEW=0
-POSITIONAL_ARGS=()
-
-# Parsing the command-line arguments
-while [[ $# -gt 0 ]]; do
-    case "$1" in
-        --skip)
-            shift # Remove --skip from processing
-            if [[ $1 == "only-new" ]]; then
-                IGNORE_NEW=1
-                shift # Remove the value from processing
-            else
-                echo "Error: --skip requires a value ( choices:[ "only-new" ])"
-                exit 1
-            fi
-            ;;
-        *)
-            # Store positional arguments
-            POSITIONAL_ARGS+=("$1")
-            shift
-            ;;
-    esac
-done
-
-# Restore positional arguments
-set -- "${POSITIONAL_ARGS[@]}"
 
 # GET FILE NAMES
 


### PR DESCRIPTION
## Description

Added the parsing logic for the optional parameter --skip, if this flag is set true then same is conveyed to _reporter.js which in turn skips the write reports if the only flag is new  `🌱`

Fixes # (issue) #7

### How Has This Been Tested?
 
 Tested on all cases like :

-  bash lib/storage-delta/run.sh <COMMIT_OR_TAG> --skip `: [ got the error as expected ]`
-  bash lib/storage-delta/run.sh <COMMIT_OR_TAG> --skip only-new `: [ result as expected, skipped the write report ]`
-  bash lib/storage-delta/run.sh <COMMIT_OR_TAG> `: [ result same as previous ] `


## Checklist:

- [x] I have used the proper Node.js version (e.g., using the `.nvmrc` file and the `nvm use` command).
- [x] I have formatted my code using prettier
- [x] I have installed [pre-commit](https://pre-commit.com/#installation) and have run `pre-commit install` to install the git hooks

